### PR TITLE
Update Node.js version to LTS in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: lts/*
       - name: Install the dependencies
         run: npm i
       - name: Install vsce


### PR DESCRIPTION
## Summary
Updated the Node.js version specification in the release workflow to use the latest LTS version instead of a pinned major version.

## Changes
- Changed `node-version` from `24` to `lts/*` in the release workflow configuration

## Details
This change makes the release workflow more flexible by automatically using the current LTS version of Node.js rather than being tied to a specific major version (24). This approach reduces the need for manual updates when Node.js versions reach end-of-life and ensures the workflow uses a stable, long-term supported version.

https://claude.ai/code/session_01JXfyb9MDsKMYa7Ynzqsj8y