### PR TITLE
Configure dependabot to ignore non-LTS Node.js versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       timezone: "Asia/Tokyo"
     cooldown:
       default-days: 3
+    ignore:
+      # Ignore non-LTS Node.js versions (odd numbers are not LTS)
+      - dependency-name: "@types/node"
+        versions: ["25.x", "27.x", "29.x", "31.x", "33.x"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

- Ignore odd-numbered `@types/node` versions (25.x, 27.x, 29.x, 31.x, 33.x) in dependabot since odd releases are not LTS

## Background

Node.js uses even version numbers for LTS releases. By ignoring odd-numbered `@types/node` versions, dependabot will only propose updates to LTS-aligned type definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)