### PR TITLE
chore: update @types/node ignore list for new Node.js release cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,10 @@ updates:
     cooldown:
       default-days: 3
     ignore:
-      # Ignore non-LTS Node.js versions (odd numbers are not LTS)
+      # Hold Node.js releases until LTS promotion (October each year).
+      # Remove an entry when it enters LTS; add the next April release as it approaches.
       - dependency-name: "@types/node"
-        versions: ["25.x", "27.x", "29.x", "31.x", "33.x"]
+        versions: ["25.x", "26.x", "27.x", "28.x"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Update the `@types/node` ignore list to match Node.js's [evolved release schedule](https://nodejs.org/en/blog/announcements/evolving-the-nodejs-release-schedule). Starting with v27, every annual major release becomes LTS (no more odd/even distinction), and the early-testing role is filled by an Alpha channel using semver prereleases (e.g. `27.0.0-alpha.1`).

The previous ignore list (`25.x, 27.x, 29.x, 31.x, 33.x`) permanently skipped odd majors, which would incorrectly skip legitimate LTS versions from v27 onward.

## New policy

Ignore each major during its 6-month Current phase and remove the entry on LTS promotion (October each year):

- `25.x` — non-LTS (last odd under old model)
- `26.x` — LTS October 2026
- `27.x` — LTS October 2027 (first under new annual-LTS model)
- `28.x` — LTS October 2028

Listing the next ~3 years keeps the file short while covering upcoming releases. Add the next April release each year as it approaches.

## Test plan

- [ ] Dependabot picks up the new config on next scheduled run
- [ ] @types/node updates to LTS-only versions are still proposed