### PR TITLE
ci: declare top-level permissions in workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,6 +7,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     types: [labeled]
 
+permissions: {}
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Declare an explicit top-level `permissions:` block on every workflow that did not already have one, so the workflow's default `GITHUB_TOKEN` is restricted to the minimum it actually needs.

This addresses the `excessive-permissions` finding from `zizmor`.

### Per-workflow notes

- `auto-merge.yml` — does not run `actions/checkout` and the only token used is the GitHub App token. The workflow's `GITHUB_TOKEN` is never touched, so `permissions: {}`.
- `release.yml` — checkout + `vsce publish` using `VSCE_PAT` from secrets; the workflow's `GITHUB_TOKEN` only needs `contents: read`.
- `actionlint.yml` — just `actions/checkout` + run a tool. `contents: read` is enough.
- `dependabot-auto-label.yml` — already declares `pull-requests: read` (needed by `dependabot/fetch-metadata`), so it is intentionally not changed here.

References:
- https://docs.zizmor.sh/audits/#excessive-permissions
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

## Test plan

- [x] Run the affected workflows on this PR and confirm they still pass.