### PR TITLE
ci: opt out of setup-node package manager cache in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
+          # Skip package manager cache to avoid the cache-poisoning attack at release time:
+          # a poisoned cache written from a PR could otherwise be reused here
+          # and end up shipped to the VS Code Marketplace.
+          # See https://docs.zizmor.sh/audits/#cache-poisoning
+          package-manager-cache: false
       - name: Install the dependencies
         run: npm i
       - name: Install vsce


### PR DESCRIPTION
## Summary
zizmor's `cache-poisoning` audit flagged `actions/setup-node` in `release.yml` because the action can enable dependency caching, and a poisoned cache from a PR build could be reused at publish time.

`actions/setup-node@v6` auto-enables package-manager caching when `package.json` contains `packageManager` or `devEngines.packageManager` (default `package-manager-cache: true`). To make the intent explicit and stay safe if `packageManager` is added later, set `package-manager-cache: false` with an inline comment, mirroring the `bundler-cache: false` pattern in the Ruby skeleton's `release.yml`.

## Test plan
- [ ] Confirm zizmor no longer reports `cache-poisoning` against `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)