### PR TITLE
ci: Pin action versions with exact-version comments

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'auto-merge'
     steps:
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}

--- a/.github/workflows/dependabot-auto-label.yml
+++ b/.github/workflows/dependabot-auto-label.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTO_MERGER_APP_ID }}
@@ -17,7 +17,7 @@ jobs:
           permission-pull-requests: write
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Add auto-merge label

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
           # Skip package manager cache to avoid the cache-poisoning attack at release time:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -14,7 +14,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Run actionlint
@@ -26,7 +26,7 @@ jobs:
   zizmor:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
## Problem

The `Workflow lint` job fails on zizmor's `ref-version-mismatch` audit (exit code 13).

Several actions are hash-pinned but commented with a **floating major tag** (e.g. `# v6`). When the action publishes a new release, that major tag moves to a newer commit than the pinned SHA, so the comment no longer matches the SHA and zizmor flags the mismatch. This recurs on every upstream release until the pin is bumped.

`actions/checkout` is the one currently failing: it is pinned to `de0fac2…` (**v6.0.2**) but commented `# v6`, which now resolves to v6.0.3.

## Fix

Normalize every hash-pinned action's comment to the **exact release** its SHA corresponds to, so the comment is stable across upstream releases. This mirrors the skill skeleton:

| action | pin |
|---|---|
| `actions/checkout` | `de0fac2…` `# v6.0.2` |
| `actions/create-github-app-token` | `bcd2ba4…` `# v3.2.0` |
| `actions/setup-node` | `48b55a0…` `# v6.4.0` |
| `dependabot/fetch-metadata` | `25dd0e3…` `# v3.1.0` |
| `peter-evans/create-pull-request` | `5f6978f…` `# v8.1.1` |
| `rubygems/release-gem` | `6317d8d…` `# v1.2.0` (SHA bumped from `f0d7faff…`) |

Only the pins present in this repo are changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
