### PR TITLE
Add npm cooldown (.npmrc min-release-age)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
## Summary

Adds `.npmrc` with `min-release-age=7` so npm does not install newly published package versions until they have been public for 7 days. This complements the existing Dependabot `cooldown` (which only protects Dependabot-authored update PRs) by also covering manual/local `npm install` / `npm update` resolution.

Requires npm 11.10.0+ to take effect; older npm silently ignores the unknown key, so this is safe to merge regardless of the npm version in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)